### PR TITLE
Sync bugfixes in MarkerLib

### DIFF
--- a/markerLib.py
+++ b/markerLib.py
@@ -101,7 +101,8 @@ alphanum_dict = {
 '7': [[(8,0), (12,0), (12,16), (0,16), (0,14), (8,14), (8,0), (8,0)]],
 '8': [[(0,0), (4,0), (4,16), (0,16), (0,10), (4,8), (0,6), (0,0)], [(4,0), (12,0), (12,6), (8,8), (12,10), (12,16), (4,16), (4,14), (8,14), (8,10), (4,10), (4,6), (8,6), (8,2), (4,2), (4,0)]],
 '9': [[(8,0), (12,0), (12,16), (8,16), (8,0)], [(8,16), (0,16), (0,8), (8,8), (8,10), (4,10), (4,14), (8,14), (8,16)]],
-'+': [[(0,6),(4,6),(4,2),(8,2),(8,6),(12,6),(12,10),(8,10),(8,14),(4,14),(4,10),(0,10),(0,6)]]
+'+': [[(0,6),(4,6),(4,2),(8,2),(8,6),(12,6),(12,10),(8,10),(8,14),(4,14),(4,10),(0,10),(0,6)]],
+'.': [[(4,0),(8,0),(8,4),(4,4)]]
 }
 
 def AlphaNumStr(chip, structure, string, size, centered=False, bgcolor=None, **kwargs):
@@ -113,6 +114,7 @@ def AlphaNumStr(chip, structure, string, size, centered=False, bgcolor=None, **k
             return structure
         elif isinstance(structure,tuple):
             return m.Structure(chip,structure)
+            #BUG - below struct().shiftPos is used so using pos instead doesn't work
         else:
             return chip.structure(structure)
     if bgcolor is None:
@@ -125,5 +127,5 @@ def AlphaNumStr(chip, structure, string, size, centered=False, bgcolor=None, **k
         scaled_size = (size[0] / 16., size[1] / 16.)
         for pts in alphanum_dict[letter]:
             scaled_pts = [(p[0]*scaled_size[0], p[1]*scaled_size[1]) for p in pts]
-            chip.add(SolidPline(insert=struct().getPos(), rotation=structure.direction, points=scaled_pts, **kwargs))
+            chip.add(SolidPline(insert=struct().getPos(), rotation=struct().direction, points=scaled_pts, **kwargs))
         struct().shiftPos(size[0])

--- a/microwaveLib.py
+++ b/microwaveLib.py
@@ -213,7 +213,7 @@ def Strip_stub_open(chip,structure,flipped=False,curve_out=True,r_out=None,w=Non
         dx = 0.
         if flipped:
             if allow_oversize:
-                dx = r_out
+                dx = max(length,r_out)
             else:
                 dx = min(w/2,r_out)
         
@@ -224,7 +224,7 @@ def Strip_stub_open(chip,structure,flipped=False,curve_out=True,r_out=None,w=Non
         
         if length is None: length=0
 
-        chip.add(RoundRect(struct().getPos((dx,0)),max(length,l),w,l,roundCorners=[0,curve_out,curve_out,0],hflip=flipped,valign=const.MIDDLE,rotation=struct().direction,bgcolor=bgcolor,**kwargs),structure=structure,length=l)
+        chip.add(RoundRect(struct().getPos((dx,0)),max(length,l),w,l,roundCorners=[0,curve_out,curve_out,0],hflip=flipped,valign=const.MIDDLE,rotation=struct().direction,bgcolor=bgcolor,**kwargs),structure=structure,length=max(l,length))
     else:
         if length is not None:
             if allow_oversize:


### PR DESCRIPTION
added '.' to AlphaNum Markers
fixed position control in AlphaNum Markers when using location tuple instead of structure
fixed length offset issue in strip_stub_open (MicrowaveLib)